### PR TITLE
fix memory consumption error

### DIFF
--- a/nodes/DocCreateField/DocCreateField.node.ts
+++ b/nodes/DocCreateField/DocCreateField.node.ts
@@ -121,7 +121,7 @@ export class DocCreateField implements INodeType {
 				returnData.push(result);
 			} catch (error) {
 				if (this.continueOnFail()) {
-					items.push({ json: this.getInputData(itemIndex)[0].json, error, pairedItem: itemIndex });
+					returnData.push({ json: this.getInputData(itemIndex)[0].json, error, pairedItem: itemIndex });
 				} else {
 					if (error.context) {
 						error.context.itemIndex = itemIndex;

--- a/nodes/DocFill/DocFill.node.ts
+++ b/nodes/DocFill/DocFill.node.ts
@@ -122,7 +122,7 @@ export class DocFill implements INodeType {
 				returnData.push(result);
 			} catch (error) {
 				if (this.continueOnFail()) {
-					items.push({ json: this.getInputData(itemIndex)[0].json, error, pairedItem: itemIndex });
+					returnData.push({ json: this.getInputData(itemIndex)[0].json, error, pairedItem: itemIndex });
 				} else {
 					if (error.context) {
 						error.context.itemIndex = itemIndex;


### PR DESCRIPTION
When operations failed with the "Continue on Fail" option enabled, the error handling logic was incorrectly pushing failed items back into the items array instead of the returnData array. This created a self-perpetuating loop where:

- Failed items were continuously reprocessed
- Each iteration added more duplicate items to memory
- Eventually leading to memory exhaustion and application failure

Fixes #1 